### PR TITLE
fix: check for python3, not python, in exec-env

### DIFF
--- a/bin/exec-env
+++ b/bin/exec-env
@@ -11,13 +11,13 @@ plugin_dir="$(dirname "$current_script_dir")"
 # shellcheck source=../lib/utils.bash
 source "${plugin_dir}/lib/utils.bash"
 
-if [[ ! -x "$(command -v python)" ]]; then
+if [[ ! -x "$(command -v python3)" ]]; then
 	log_failure_and_exit "Python not found and is required for gcloud. Might I suggest https://github.com/danhper/asdf-python"
 fi
 
 # credit: https://unix.stackexchange.com/a/56846/397902
 if [ -z "${CLOUDSDK_PYTHON:+1}" ]; then
 	# undefined or defined and empty
-	python_sdk="$(command -v python)"
+	python_sdk="$(command -v python3)"
 	export CLOUDSDK_PYTHON=${python_sdk}
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

This fix enables the use of Homebrew-installed Python with this plugin. 

See also 9d7ff92 for an earlier commit that adjusted `python` --> `python3`.

## Description

<!--- Describe your changes in detail -->

Changes `bin/exec-env` to check for `python3` instead of `python`.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

Not working, on macOS with Homebrew-installed Python:

➜  ~ gcloud --version
🚨  Python not found and is required for gcloud. Might I suggest https://github.com/danhper/asdf-python
➜  ~ command -v python
➜  ~ 
➜ ~ command -v python3
/opt/homebrew/bin/python3

An alias doesn't fix it either:

➜  ~ command -v python 
alias python=python3
➜ ~ command -v python3
/opt/homebrew/bin/python3
➜  ~ gcloud help     
🚨  Python not found and is required for gcloud. Might I suggest https://github.com/danhper/asdf-python
➜  ~ which python
python: aliased to python3
➜  ~ which python3
/opt/homebrew/bin/python3

After applying the change, it works:

➜  ~ gcloud --version
Google Cloud SDK 433.0.0
bq 2.0.93
core 2023.05.26
gcloud-crc32c 1.0.0
gsutil 5.24

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Usage examples

<!--- Provide examples of intended usage -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
